### PR TITLE
商品情報編集機能

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -22,6 +22,10 @@ class ItemsController < ApplicationController
     @item = Item.find(params[:id])
   end
 
+  def edit
+    @item = Item.find(params[:id])
+  end
+
   private
 
   def item_params

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -27,7 +27,6 @@ class ItemsController < ApplicationController
   end
 
   def update
-    @item.update(item_params)
     if @item.update(item_params)
       redirect_to action: :show
     else

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,5 +1,6 @@
 class ItemsController < ApplicationController
   before_action :authenticate_user!, except: [:index, :show]
+  before_action :url_direct_hit_prevention, only: :edit     # 学習用メモ：def edit 〜 end より先に、このコードが読み込まれる。
 
   def index
     @items = Item.order("created_at DESC")
@@ -26,10 +27,31 @@ class ItemsController < ApplicationController
     @item = Item.find(params[:id])
   end
 
+  def update
+    @item = Item.find(params[:id])
+    @item.update(item_params)
+    if @item.update(item_params)
+      redirect_to action: :show
+    else
+      render :edit
+    end
+  end
+
+  # def destroy
+  #   @item = Item.find(params[:id])
+  # end
+
   private
 
   def item_params
     params.require(:item).permit(:item_name, :content, :category_id, :condition_id, :postage_id, :region_id, :shopping_date_id, :price, :image).merge(user_id: current_user.id)
+  end
+
+  def url_direct_hit_prevention
+    @item = Item.find(params[:id])
+    if @item.user.id != current_user.id
+      redirect_to root_path
+    end
   end
 
 end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,5 +1,6 @@
 class ItemsController < ApplicationController
   before_action :authenticate_user!, except: [:index, :show]
+  before_action :set_item, only: [:show, :edit, :update]
   before_action :url_direct_hit_prevention, only: :edit     # 学習用メモ：def edit 〜 end より先に、このコードが読み込まれる。
 
   def index
@@ -20,15 +21,12 @@ class ItemsController < ApplicationController
   end
 
   def show
-    @item = Item.find(params[:id])
   end
 
   def edit
-    @item = Item.find(params[:id])
   end
 
   def update
-    @item = Item.find(params[:id])
     @item.update(item_params)
     if @item.update(item_params)
       redirect_to action: :show
@@ -47,8 +45,11 @@ class ItemsController < ApplicationController
     params.require(:item).permit(:item_name, :content, :category_id, :condition_id, :postage_id, :region_id, :shopping_date_id, :price, :image).merge(user_id: current_user.id)
   end
 
-  def url_direct_hit_prevention
+  def set_item
     @item = Item.find(params[:id])
+  end
+
+  def url_direct_hit_prevention
     if @item.user.id != current_user.id
       redirect_to root_path
     end

--- a/app/views/items/edit.html.erb
+++ b/app/views/items/edit.html.erb
@@ -1,5 +1,6 @@
-<%# cssは商品出品のものを併用しています。
-app/assets/stylesheets/items/new.css %>
+<%# 作業メモ ：cssは商品出品のものを併用している。app/assets/stylesheets/items/new.css %>
+<%# 作業メモ ：ログイン状態でも、自身が出品した売却済みの商品だと、編集ページでなくトップページに遷移されるようにしよう
+             注意) 商品購入機能実装後に実装すること %>
 
 <div class="items-sell-contents">
   <header class="items-sell-header">
@@ -7,11 +8,9 @@ app/assets/stylesheets/items/new.css %>
   </header> 
   <div class="items-sell-main">
     <h2 class="items-sell-title">商品の情報を入力</h2>
-    <%= form_with local: true do |f| %>
+    <%= form_with model: @item, local: true do |f| %>
 
-    <%# インスタンスを渡して、エラー発生時にメッセージが表示されるようにしましょう。%>
-    <%# render 'shared/error_messages', model: f.object %>
-    <%# //インスタンスを渡して、エラー発生時にメッセージが表示されるようにしましょう。%>
+    <%= render 'shared/error_messages', model: f.object %>
 
     <%# 商品画像 %>
     <div class="img-upload">
@@ -23,7 +22,7 @@ app/assets/stylesheets/items/new.css %>
         <p>
           クリックしてファイルをアップロード
         </p>
-        <%= f.file_field :hoge, id:"item-image" %>
+        <%= f.file_field :image, id:"item-image" %>
       </div>
     </div>
     <%# /商品画像 %>
@@ -33,13 +32,13 @@ app/assets/stylesheets/items/new.css %>
         商品名
         <span class="indispensable">必須</span>
       </div>
-      <%= f.text_area :hoge, class:"items-text", id:"item-name", placeholder:"商品名（必須 40文字まで)", maxlength:"40" %>
+      <%= f.text_area :item_name, class:"items-text", id:"item-name", placeholder:"商品名（必須 40文字まで)", maxlength:"40" %>
       <div class="items-explain">
         <div class="weight-bold-text">
           商品の説明
           <span class="indispensable">必須</span>
         </div>
-        <%= f.text_area :hoge, class:"items-text", id:"item-info", placeholder:"商品の説明（必須 1,000文字まで）（色、素材、重さ、定価、注意点など）例）2010年頃に1万円で購入したジャケットです。ライトグレーで傷はありません。あわせやすいのでおすすめです。" ,rows:"7" ,maxlength:"1000" %>
+        <%= f.text_area :content, class:"items-text", id:"item-info", placeholder:"商品の説明（必須 1,000文字まで）（色、素材、重さ、定価、注意点など）例）2010年頃に1万円で購入したジャケットです。ライトグレーで傷はありません。あわせやすいのでおすすめです。" ,rows:"7" ,maxlength:"1000" %>
       </div>
     </div>
     <%# /商品名と商品説明 %>
@@ -52,12 +51,12 @@ app/assets/stylesheets/items/new.css %>
           カテゴリー
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-category"}) %>
+        <%= f.collection_select(:category_id, Category.all, :id, :name, {}, {class:"select-box", id:"item-category"}) %>
         <div class="weight-bold-text">
           商品の状態
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-sales-status"}) %>
+        <%= f.collection_select(:condition_id, Condition.all, :id, :name, {}, {class:"select-box", id:"item-sales-status"}) %>
       </div>
     </div>
     <%# /商品の詳細 %>
@@ -73,17 +72,17 @@ app/assets/stylesheets/items/new.css %>
           配送料の負担
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-shipping-fee-status"}) %>
+        <%= f.collection_select(:postage_id, Postage.all, :id, :name, {}, {class:"select-box", id:"item-shipping-fee-status"}) %>
         <div class="weight-bold-text">
           発送元の地域
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-prefecture"}) %>
+        <%= f.collection_select(:region_id, Region.all, :id, :name, {}, {class:"select-box", id:"item-prefecture"}) %>
         <div class="weight-bold-text">
           発送までの日数
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-scheduled-delivery"}) %>
+        <%= f.collection_select(:shopping_date_id, ShoppingDate.all, :id, :name, {}, {class:"select-box", id:"item-scheduled-delivery"}) %>
       </div>
     </div>
     <%# /配送について %>
@@ -101,7 +100,7 @@ app/assets/stylesheets/items/new.css %>
             <span class="indispensable">必須</span>
           </div>
           <span class="sell-yen">¥</span>
-          <%= f.text_field :hoge, class:"price-input", id:"item-price", placeholder:"例）300" %>
+          <%= f.text_field :price, class:"price-input", id:"item-price", placeholder:"例）300" %>
         </div>
         <div class="price-content">
           <span>販売手数料 (10%)</span>
@@ -141,7 +140,7 @@ app/assets/stylesheets/items/new.css %>
     <%# 下部ボタン %>
     <div class="sell-btn-contents">
       <%= f.submit "変更する" ,class:"sell-btn" %>
-      <%=link_to 'もどる', "#", class:"back-btn" %>
+      <%=link_to 'もどる', root_path, class:"back-btn" %>
     </div>
     <%# /下部ボタン %>
   </div>

--- a/app/views/items/edit.html.erb
+++ b/app/views/items/edit.html.erb
@@ -140,7 +140,7 @@
     <%# 下部ボタン %>
     <div class="sell-btn-contents">
       <%= f.submit "変更する" ,class:"sell-btn" %>
-      <%=link_to 'もどる', root_path, class:"back-btn" %>
+      <%=link_to 'もどる', item_path, method: :get, class:"back-btn" %>
     </div>
     <%# /下部ボタン %>
   </div>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -92,10 +92,10 @@
       <li class='list'>
         <%= image_tag "furima-intro04.png", class:"list-pict" %>
         <h3 class='feature-list-text'>
-          簡単に売り買い可能
+          簡単に売り買いできる
         </h3>
         <p class='feature-list-description'>
-          スマホひとつで、いつでもどこでも簡単に出品・購入ができます。
+          スマホひとつで、いつでもどこでも簡単に出品・購入が可能！
         </p>
       </li>
       <li class='list'>
@@ -113,7 +113,7 @@
           様々な支払いに対応
         </h3>
         <p class='feature-list-description'>
-          お支払いはクレジットカードだけでなく、ポイントや売上金など、多彩な方法があります。
+          お支払いは、クレジットカードだけでなく、ポイントや売上金など多彩な方法があります。
         </p>
       </li>
     </ul>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -92,10 +92,10 @@
       <li class='list'>
         <%= image_tag "furima-intro04.png", class:"list-pict" %>
         <h3 class='feature-list-text'>
-          簡単に売り買いできる
+          簡単に売り買い可能
         </h3>
         <p class='feature-list-description'>
-          スマホひとつで、いつでもどこでも簡単に出品・購入が可能！
+          スマホひとつで、いつでもどこでも簡単に出品・購入ができます。
         </p>
       </li>
       <li class='list'>
@@ -113,7 +113,7 @@
           様々な支払いに対応
         </h3>
         <p class='feature-list-description'>
-          お支払いは、クレジットカードだけでなく、ポイントや売上金など多彩な方法があります。
+          お支払いはクレジットカードだけでなく、ポイントや売上金など、多彩な方法があります。
         </p>
       </li>
     </ul>

--- a/app/views/items/new.html.erb
+++ b/app/views/items/new.html.erb
@@ -137,7 +137,7 @@
     <%# 下部ボタン %>
     <div class="sell-btn-contents">
       <%= f.submit "出品する" ,class:"sell-btn" %>
-      <%=link_to 'もどる', root_path, class:"back-btn" %>
+      <%= link_to 'もどる', root_path, class:"back-btn" %>
     </div>
     <%# /下部ボタン %>
   </div>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -25,7 +25,7 @@
 
     <%# 整理用メモ①：ログイン中かつ、出品者と閲覧者が同一かどうか(編集・削除が操作できるように) %>
     <% if user_signed_in? && current_user.id == @item.user_id %>
-      <%= link_to "商品の編集", "#", method: :get, class: "item-red-btn" %>
+      <%= link_to "商品の編集", edit_item_path, method: :get, class: "item-red-btn" %>
       <p class="or-text">or</p>
       <%= link_to "削除", "#", method: :delete, class:"item-destroy" %>
     <%# 整理用メモ②：ログイン中だが、出品者と閲覧者が同一ではない(購入ができるように) %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -83,9 +83,9 @@
     <form>
       <textarea class="comment-text"></textarea>
       <p class="comment-warn">
-        相手のことを考え丁寧なコメントを心がけましょう。
+        相手のことを考え、丁寧なコメントを心がけましょう。
         <br>
-        不快な言葉遣いなどは利用制限や退会処分となることがあります。
+        不快な言葉遣いなどは、利用制限や退会処分となることがあります。
       </p>
       <button type="submit" class="comment-btn">
         <%= image_tag "comment.png" ,class:"comment-flag-icon" ,width:"20",height:"25"%>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
   devise_for :users
   root to: 'items#index'
-  resources :items, only: [:index, :new, :create, :show, :edit]
+  resources :items, only: [:index, :new, :create, :show, :edit, :update]
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
   devise_for :users
   root to: 'items#index'
-  resources :items, only: [:index, :new, :create, :show]
+  resources :items, only: [:index, :new, :create, :show, :edit]
 end


### PR DESCRIPTION
# What
登録されている商品情報を、編集できるようにした。

# Why
フリマアプリの実装に伴い、出品済みの商品の情報を編集できるようにしたいから。

# 出品者が編集ページに移動できる動画(ログイン状態)
https://i.gyazo.com/9d7e184bf0797a796825245c65be2545.mp4

# 入力内容に問題がなければ、商品情報が編集できる動画
https://i.gyazo.com/799d22f8e84f571244705808f45f0ec4.mp4

# 入力内容に問題があれば、情報は保存されず編集ページに戻り、エラーメッセージが表示される動画
https://i.gyazo.com/9c20d90e9337d1b35cadf243b2b5ca67.mp4

# 何も編集せずに更新ボタンを押しても、画像なしの商品にならない動画
https://i.gyazo.com/2b4906384af1b5703ba825d0fd89c303.mp4

# ログインユーザー自身が出品してない商品の編集ページに移動するURLを直打ちすると、トップページが表示される動画
https://i.gyazo.com/ed7f7f6627de443b2895d49d379bd4a8.mp4

# ログアウト状態では、商品の編集ページに移動するURLを直打ちすると、ログインページが表示される動画
https://i.gyazo.com/ca4044162a7acb3527831693b1d788ec.mp4

# 既に登録済みの商品情報は、編集ページを開いた時点で表示される動画
https://i.gyazo.com/0d762c071cb726d65e8ed9e5725038c0.mp4